### PR TITLE
fix: read weight twice to get current data

### DIFF
--- a/src/scale_driver/scale_tcp_ip.py
+++ b/src/scale_driver/scale_tcp_ip.py
@@ -172,6 +172,8 @@ class scaleDriver(RComponent):
         response = getWeightResponse()
         try:
             self.write_socket_lock(self.readWeight_msg)
+            # Perform read twice, to get rid of outdated info
+            data = self.read_socket_lock()
             data = self.read_socket_lock()
             dataSplit = data.split()
             response.status = dataSplit[0]


### PR DESCRIPTION
First socket read outputs outdated info - workaround for not having to call read weight service twice